### PR TITLE
remove sign in link from header

### DIFF
--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -33,10 +33,6 @@
           {{link "sign_out" role="menuitem"}}
         </div>
       </div>
-    {{else}}
-      {{#link "sign_in" class="sign-in"}}
-        {{t 'sign_in'}}
-      {{/link}}
     {{/if}}
   </div>
 </header>


### PR DESCRIPTION
## Description

Removes else directive from header so that sign in does not link appear when user is not authenticated. We don't want users to attempt to sign in at all

## Screenshots

<!-- (optional) when applicable, please include some screenshots or gifs that illustrate the changes -->